### PR TITLE
fix(ui): correct lang attribute for <html> tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="h-100">
+<html lang="zh-Hans-CN" class="h-100">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="public/favicon.ico" />


### PR DESCRIPTION
Browsers use the declared language in the process of selecting typefaces to use, and some fonts (notably Source Han family) choose different variants for the same code point according to the language.

On some setups, CJK script with lang="en" makes the browser choose Japanese fonts instead of Chinese ones. This commit corrects the language attribute to lang="zh-Hans-CN".